### PR TITLE
Correct Minor Syntax Error

### DIFF
--- a/server/documents/introduction/advanced-usage.html.eco
+++ b/server/documents/introduction/advanced-usage.html.eco
@@ -24,8 +24,8 @@ type        : 'Introduction'
       build = require('./semantic/tasks/build')
     ;
     // import task with a custom task name
-    gulp.task('watch ui', watch));
-    gulp.task('build ui', build));
+    gulp.task('watch ui', watch);
+    gulp.task('build ui', build);
     </div>
   </div>
 


### PR DESCRIPTION
For the gulp task include example, there were a couple extra parentheses.
